### PR TITLE
Add a label of Google Japanese Input

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -183,6 +183,12 @@ case $label in
         updateToolArguments=( -runMode oneshot -userInitiated YES )
         updateToolRunAsCurrentUser=1
         ;;
+    googlejapaneseinput)
+        name="Google Japanese Input"
+        type="pkgInDmg"
+        downloadURL="https://dl.google.com/japanese-ime/latest/GoogleJapaneseInput.dmg"
+        expectedTeamID="EQHXZ8M8AV"
+        ;;
     spotify)
         name="Spotify"
         type="dmg"

--- a/Labels.txt
+++ b/Labels.txt
@@ -14,6 +14,7 @@ firefox
 githubdesktop
 googlechrome
 googlechromepkg
+googlejapaneseinput
 googledrivefilestream
 grandperspective
 handbrake


### PR DESCRIPTION
Google Japanese Input is one of the most popular Japanese input IME software.

https://www.google.co.jp/ime/