### PR TITLE
Only match GitHub files that end in the filetype

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -147,7 +147,7 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
     | awk -F '"' "/browser_download_url/ && /$archiveName/ { print \$4 }")
     else
     downloadURL=$(curl --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" \
-    | awk -F '"' "/browser_download_url/ && /$filetype/ { print \$4 }")
+    | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4 }")
     fi
     if [ -z "$downloadURL" ]; then
         printlog "could not retrieve download URL for $gitusername/$gitreponame"


### PR DESCRIPTION
Some GitHub repos (e.g. keepassxreboot/keepassxc) `downloadURLFromGit()` returns multiple files matching the filetype, e.g. `filename.dmg`, `filename.dmg.DIGEST`, etc. and installation will fail.

By requiring the end quote to match, the function only returns the one file that ends in the filetype and installation will succeed.