### PR TITLE
Add AirServer label

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -791,6 +791,12 @@ snagit2020)
     downloadURL="https://download.techsmith.com/snagitmac/releases/Snagit.dmg"
     expectedTeamID="7TQL462TU8"
     ;;
+airserver)
+    name="AirServer"
+    type="dmg"
+    downloadURL="https://www.airserver.com/download/mac/latest"
+    expectedTeamID="6C755KS5W3"
+    ;;
 
 
 # MARK: add new labels above here

--- a/Labels.txt
+++ b/Labels.txt
@@ -3,6 +3,7 @@
 adobereaderdc
 adobereaderdc-install
 adobereaderdc-update
+airserver
 appcleaner
 aquaskk
 atom


### PR DESCRIPTION
Successful debug output run:

```
sh Installomator.sh airserver
2020-08-23 23:52:39 ################## Start Installomator
2020-08-23 23:52:39 ################## airserver
2020-08-23 23:52:39 no blocking processes defined, using AirServer as default
2020-08-23 23:52:39 Changing directory to .
2020-08-23 23:52:40 Spotlight not returning any app, trying manually in /Applications.
Installomator.sh: line 1055: ${(0)applist}: bad substitution
2020-08-23 23:52:40 DEBUG mode, not checking for blocking processes
2020-08-23 23:52:40 Downloading https://www.airserver.com/download/mac/latest to AirServer.dmg
2020-08-23 23:52:42 Mounting ./AirServer.dmg
2020-08-23 23:52:44 Mounted: /Volumes/AirServer 7.2.6 1
2020-08-23 23:52:44 Verifying: /Volumes/AirServer 7.2.6 1/AirServer.app
2020-08-23 23:52:44 Team ID: 6C755KS5W3 (expected: 6C755KS5W3 )
2020-08-23 23:52:44 DEBUG enabled, skipping copy and chown steps
2020-08-23 23:52:55 Spotlight not returning any app, trying manually in /Applications.
Installomator.sh: line 1055: ${(0)applist}: bad substitution
2020-08-23 23:52:55 Installed AirServer
2020-08-23 23:52:55 notifying
2020-08-23 23:52:55 Unmounting /Volumes/AirServer 7.2.6 1
"disk3" ejected.
2020-08-23 23:52:55 ################## End Installomator 
```