### PR TITLE
Add VirtualBox label

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -791,6 +791,14 @@ snagit2020)
     downloadURL="https://download.techsmith.com/snagitmac/releases/Snagit.dmg"
     expectedTeamID="7TQL462TU8"
     ;;
+virtualbox)
+    name="VirtualBox"
+    type="pkgInDmg"
+    pkgName="VirtualBox.pkg"
+    downloadURL=$(curl -fs "https://www.virtualbox.org/wiki/Downloads" \
+        | awk -F '"' "/OSX.dmg/ { print \$4 }")
+    expectedTeamID="VB5E2TV963"
+    ;;
 
 
 # MARK: add new labels above here

--- a/Labels.txt
+++ b/Labels.txt
@@ -90,6 +90,7 @@ things
 torbrowser
 tunnelbear
 umbrellaroamingclient
+virtualbox
 visualstudiocode
 vlc
 webexmeetings


### PR DESCRIPTION
Successful debug output:

```
sh Installomator.sh virtualbox
2020-08-24 00:46:17 ################## Start Installomator
2020-08-24 00:46:17 ################## virtualbox
2020-08-24 00:46:18 no blocking processes defined, using VirtualBox as default
2020-08-24 00:46:18 Changing directory to .
Installomator.sh: line 1056: ${(0)applist}: bad substitution
2020-08-24 00:46:18 DEBUG mode, not checking for blocking processes
2020-08-24 00:46:18 Downloading https://download.virtualbox.org/virtualbox/6.1.12/VirtualBox-6.1.12-139181-OSX.dmg to VirtualBox.dmg
2020-08-24 00:46:25 Mounting ./VirtualBox.dmg
2020-08-24 00:46:32 Mounted: /Volumes/VirtualBox 1
2020-08-24 00:46:32 Verifying: /Volumes/VirtualBox 1/VirtualBox.pkg
2020-08-24 00:46:32 Team ID: VB5E2TV963 (expected: VB5E2TV963 )
2020-08-24 00:46:32 DEBUG enabled, skipping installation
Installomator.sh: line 1056: ${(0)applist}: bad substitution
2020-08-24 00:46:42 Installed VirtualBox
2020-08-24 00:46:42 notifying
2020-08-24 00:46:42 Unmounting /Volumes/VirtualBox 1
"disk3" ejected.
2020-08-24 00:46:42 ################## End Installomator 
```