### PR TITLE
Add iStat Menus

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -839,6 +839,12 @@ keepassxc)
     downloadURL="$(downloadURLFromGit keepassxreboot keepassxc)"
     expectedTeamID="G2S7P7J672"
     ;;
+istatmenus)
+    name="iStat Menus"
+    type="zip"
+    downloadURL="https://download.bjango.com/istatmenus/"
+    expectedTeamID="Y93TK974AT"
+    ;;
 
 
 # MARK: add new labels above here

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -844,6 +844,7 @@ istatmenus)
     type="zip"
     downloadURL="https://download.bjango.com/istatmenus/"
     expectedTeamID="Y93TK974AT"
+    blockingProcesses=( "iStat Menus" "iStatMenusAgent" "iStat Menus Status" )
     ;;
 
 

--- a/Labels.txt
+++ b/Labels.txt
@@ -38,6 +38,7 @@ googlejapaneseinput
 grandperspective
 handbrake
 icons
+istatmenus
 iterm2
 jamfmigrator
 jamfpppcutility


### PR DESCRIPTION
Successful debug output:
```
2020-08-25 20:03:08 ################## Start Installomator
2020-08-25 20:03:08 ################## istatmenus
2020-08-25 20:03:08 no blocking processes defined, using iStat Menus as default
2020-08-25 20:03:08 Changing directory to .
Installomator.sh: line 1103: ${(0)applist}: bad substitution
2020-08-25 20:03:08 DEBUG mode, not checking for blocking processes
2020-08-25 20:03:08 Downloading https://download.bjango.com/istatmenus/ to iStat Menus.zip
2020-08-25 20:03:10 Unzipping iStat Menus.zip
2020-08-25 20:03:11 Verifying: ./iStat Menus.app
2020-08-25 20:03:11 Team ID: Y93TK974AT (expected: Y93TK974AT )
2020-08-25 20:03:11 DEBUG enabled, skipping copy and chown steps
Installomator.sh: line 1103: ${(0)applist}: bad substitution
2020-08-25 20:03:22 Installed iStat Menus
2020-08-25 20:03:22 notifying
2020-08-25 20:03:22 ################## End Installomator 
```