### PR TITLE
Add Alfred

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -839,6 +839,13 @@ keepassxc)
     downloadURL="$(downloadURLFromGit keepassxreboot keepassxc)"
     expectedTeamID="G2S7P7J672"
     ;;
+alfred)
+    name="Alfred"
+    type="dmg"
+    downloadURL=$(curl -fs https://www.alfredapp.com | awk -F '"' "/dmg/ {print \$2}" | head -1)
+    appName="Alfred 4.app"
+    expectedTeamID="XZZXE9SED4"
+    ;;
 
 
 # MARK: add new labels above here

--- a/Labels.txt
+++ b/Labels.txt
@@ -4,6 +4,7 @@ adobereaderdc
 adobereaderdc-install
 adobereaderdc-update
 airserver
+alfred
 appcleaner
 aquaskk
 atom


### PR DESCRIPTION
Successful debug output.  FYI, even though the app is named `Alfred 4.app` process name is still just `Alfred`

```
2020-08-25 20:16:45 ################## Start Installomator
2020-08-25 20:16:45 ################## alfred
2020-08-25 20:16:46 no blocking processes defined, using Alfred as default
2020-08-25 20:16:46 Changing directory to .
Installomator.sh: line 1103: ${(0)applist}: bad substitution
2020-08-25 20:16:46 DEBUG mode, not checking for blocking processes
2020-08-25 20:16:46 Downloading https://cachefly.alfredapp.com/Alfred_4.1_1167.dmg to Alfred.dmg
2020-08-25 20:16:46 Mounting ./Alfred.dmg
2020-08-25 20:16:47 Mounted: /Volumes/Alfred
2020-08-25 20:16:47 Verifying: /Volumes/Alfred/Alfred 4.app
2020-08-25 20:16:47 Team ID: XZZXE9SED4 (expected: XZZXE9SED4 )
2020-08-25 20:16:47 DEBUG enabled, skipping copy and chown steps
Installomator.sh: line 1103: ${(0)applist}: bad substitution
2020-08-25 20:16:57 Installed Alfred
2020-08-25 20:16:57 notifying
2020-08-25 20:16:58 Unmounting /Volumes/Alfred
"disk2" ejected.
2020-08-25 20:16:58 ################## End Installomator 
```