### PR TITLE
Changed team id to from 9BNSXJN65R to KL8N8XSYF4

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1032,7 +1032,13 @@ microsoftdefenderatp)
     updateToolArguments=( --install --apps WDAV00 )
     ;;
 
-
+theunarchiver)
+    name="The Unarchiver"
+    type="dmg"
+    downloadURL="https://dl.devmate.com/com.macpaw.site.theunarchiver/TheUnarchiver.dmg"
+    expectedTeamID="S8EX82NJP6"
+    ;;
+    
 # these descriptions exist for testing and are intentionally broken
 brokendownloadurl)
     name="Google Chrome"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -641,7 +641,7 @@ brave)
     name="Brave Browser"
     type="dmg"
     downloadURL="https://laptop-updates.brave.com/latest/osx"
-    expectedTeamID="9BNSXJN65R"
+    expectedTeamID="KL8N8XSYF4"
     ;;
 umbrellaroamingclient)
     # credit: Tadayuki Onishi (@kenchan0130)

--- a/Labels.txt
+++ b/Labels.txt
@@ -95,6 +95,7 @@ suspiciouspackage
 swiftruntimeforcommandlinetools
 teamviewer
 textmate
+theunarchiver
 things
 torbrowser
 tunnelbear


### PR DESCRIPTION
Installomator v0.4 uses the same team-id for both Docker and Brave. 
The correct team-id for Brave is found by;

`codesign -dv -vvv /Applications/Brave\ Browser.app/ 2>&1| grep Authority`

The result is: 
`Authority=Developer ID Application: Brave Software, Inc. (KL8N8XSYF4)`

Also added The Unarchiver label