### PR TITLE
Prompt the user only once

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -249,7 +249,7 @@ checkRunningProcesses() {
                       printlog "killing process $x"
                       pkill $x
                       ;;
-                    prompt_user)
+                    prompt_user|prompt_user_then_kill)
                       # prompt the user once
                       if [[ $button = "" ]]; then
                         button=$(displaydialog "Quit “$x” to continue updating? (Leave this dialogue if you want to activate this update later)." "The application “$x” needs to be updated.")

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -250,7 +250,11 @@ checkRunningProcesses() {
                       pkill $x
                       ;;
                     prompt_user)
-                      button=$(displaydialog "Quit “$x” to continue updating? (Leave this dialogue if you want to activate this update later)." "The application “$x” needs to be updated.")
+                      # prompt the user once
+                      if [[ $button = "" ]]; then
+                        button=$(displaydialog "Quit “$x” to continue updating? (Leave this dialogue if you want to activate this update later)." "The application “$x” needs to be updated.")
+                      fi
+
                       if [[ $button = "Not Now" ]]; then
                         cleanupAndExit 10 "user aborted update"
                       else


### PR DESCRIPTION
Since the prompt is in a for loop, it could be triggered 3 times if the process
does not exit in time. This change makes the script only prompt once, then
remembers the button.