### PR TITLE
Add vagrant

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1725,6 +1725,15 @@ menumeters)
     downloadURL=$(downloadURLFromGit yujitach MenuMeters )
     expectedTeamID="95AQ7YKR5A"
     ;;
+vagrant)
+    # credit: AP Orlebeke (@apizz)
+    name="Vagrant"
+    type="pkgInDmg"
+    pkgName="vagrant.pkg"
+    downloadURL=$(curl -fs https://www.vagrantup.com/downloads.html \
+        | tr '><' '\n' | awk -F'"' '/x86_64.dmg/ {print $6}' | head -1)
+    expectedTeamID="D38WU7D763"
+    ;;
 
 # MARK: add new labels above here
 


### PR DESCRIPTION
The XML from the vagrant downloads page is one giant html document with no spaces.  If there's a better & more efficient way of parsing this, please lmk or update according so it can serve as a template for other similarly formatted websites.