### PR TITLE
If a zip file has the pkg in a folder …

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -98,8 +98,8 @@ BLOCKING_PROCESS_ACTION=prompt_user
 #   When a workflow has no blocking processes, use
 #     blockingProcesses=( NONE )
 #
-# - pkgName: (optional, only used for dmgInPkg and dmgInZip)
-#   File name of the pkg file _inside_ the dmg or zip
+# - pkgName: (optional, only used for pkgInDmg, dmgInZip, and appInDmgInZip)
+#   File name of the pkg/dmg file _inside_ the dmg or zip
 #   When not given the pkgName is derived from the $name
 #
 # - updateTool:

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -491,8 +491,8 @@ installPkgInZip() {
 
     # locate pkg in zip
     if [[ -z $pkgName ]]; then
-        # find first file starting with $name and ending with 'pkg'
-        findfiles=$(find "$tmpDir" -iname "*.pkg" -maxdepth 1  )
+        # find first file ending with 'pkg'
+        findfiles=$(find "$tmpDir" -iname "*.pkg" -maxdepth 2  )
         filearray=( ${(f)findfiles} )
         if [[ ${#filearray} -eq 0 ]]; then
             cleanupAndExit 20 "couldn't find pkg in zip $archiveName"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -98,7 +98,7 @@ BLOCKING_PROCESS_ACTION=prompt_user
 #   When a workflow has no blocking processes, use
 #     blockingProcesses=( NONE )
 #
-# - pkgName: (optional, only used for pkgInDmg and dmgInZip)
+# - pkgName: (optional, only used for dmgInPkg and dmgInZip)
 #   File name of the pkg file _inside_ the dmg or zip
 #   When not given the pkgName is derived from the $name
 #

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -98,8 +98,8 @@ BLOCKING_PROCESS_ACTION=prompt_user
 #   When a workflow has no blocking processes, use
 #     blockingProcesses=( NONE )
 #
-# - pkgName: (optional, only used for pkgInDmg, dmgInZip, and appInDmgInZip)
-#   File name of the pkg/dmg file _inside_ the dmg or zip
+# - pkgName: (optional, only used for pkgInDmg and dmgInZip)
+#   File name of the pkg file _inside_ the dmg or zip
 #   When not given the pkgName is derived from the $name
 #
 # - updateTool:


### PR DESCRIPTION
… then we need to search one level deeper. And the comment to find some text beginning with something is not really correct. silnite5 is an example of this.