### PR TITLE
Fixed DBeaver URL

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1445,8 +1445,8 @@ androidfiletransfer)
 dbeaverce)
     # credit: Adrian Bühler (@midni9ht)
     name="DBeaver"
-    type="pkg"
-    downloadURL="https://dbeaver.io/files/dbeaver-ce-latest-installer.pkg"
+    type="dmg"
+    downloadURL="https://dbeaver.io/files/dbeaver-ce-latest-macos.dmg"
     expectedTeamID="42B6MDKMW8"
     blockingProcesses=( dbeaver )
     ;;


### PR DESCRIPTION
DBeaver now ships as DMG (was a PKG before). Fixed the URL for that matter, so download works again.