### PR TITLE
Fix broken DBeaver install

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1443,10 +1443,10 @@ androidfiletransfer)
     expectedTeamID="EQHXZ8M8AV"
     ;;
 dbeaverce)
-    # credit: Adrian Bühler (@midni9ht)
+    # credit: Adrian Bühler (@midni9ht) @ Gabe Marchan (darklink87)
     name="DBeaver"
-    type="pkg"
-    downloadURL="https://dbeaver.io/files/dbeaver-ce-latest-installer.pkg"
+    type="dmg"
+    downloadURL="https://dbeaver.io/files/dbeaver-ce-latest-macos.dmg"
     expectedTeamID="42B6MDKMW8"
     blockingProcesses=( dbeaver )
     ;;


### PR DESCRIPTION
PKG is no longer available and the download link is no longer functional. Updating it to use DMG with the updated download link.