### PR TITLE
Added 'tbz' to type values

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -86,6 +86,7 @@ INSTALL=""
 #     - dmg
 #     - pkg
 #     - zip
+#     - tbz
 #     - pkgInDmg
 #     - pkgInZip
 #     - appInDmgInZip


### PR DESCRIPTION
tbz (used for handling tar files) is missing in the list of type values. Added that one.