### PR TITLE
Improved 'pycharmce' for Apple Silicon

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -2010,7 +2010,12 @@ promiseutilityr)
 pycharmce)
     name="PyCharm CE"
     type="dmg"
-    downloadURL="https://download.jetbrains.com/product?code=PCC&latest&distribution=mac"
+    appNewVersion=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release" | grep -o 'version*.*,' | cut -d '"' -f3)
+    if [[ $(arch) == i386 ]]; then
+      downloadURL=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release" | grep -o "mac*.*.dmg" | cut -d '"' -f5)
+    elif [[ $(arch) == arm64 ]]; then
+      downloadURL=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release" | grep -o "macM1*.*.dmg" | cut -d '"' -f5)
+    fi
     expectedTeamID="2ZEFAR8TH3"
     #Company="JetBrains"
     ;;


### PR DESCRIPTION
Improved 'pycharmce' to make it distinguish between Intel and Apple Silicon architectures.
Added 'appNewVersion' to check for latest version.