### PR TITLE
Added M1 URL for PyCharm CE. Changed PyCharm (Pro) URLs to direct links.

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1613,6 +1613,8 @@ jetbrainsphpstorm)
     ;;
 jetbrainspycharm)
     # credit: Adrian Bühler (@midni9ht)
+    # This is the Pro version of PyCharm.
+    # Do not confuse with PyCharm CE.
     name="PyCharm"
     type="dmg"
     appNewVersion=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release" | grep -o 'version*.*,' | cut -d '"' -f3)

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1628,7 +1628,12 @@ jetbrainspycharmce|\
 pycharmce)
     name="PyCharm CE"
     type="dmg"
-    downloadURL="https://download.jetbrains.com/product?code=PCC&latest&distribution=mac"
+    appNewVersion=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release" | grep -o 'version*.*,' | cut -d '"' -f3)
+    if [[ $(arch) == i386 ]]; then
+      downloadURL="https://download.jetbrains.com/product?code=PCC&latest&distribution=mac"
+    elif [[ $(arch) == arm64 ]]; then
+      downloadURL="https://download.jetbrains.com/product?code=PCC&latest&distribution=macM1"
+    fi
     expectedTeamID="2ZEFAR8TH3"
     #Company="JetBrains"
     ;;

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1617,11 +1617,10 @@ jetbrainspycharm)
     type="dmg"
     appNewVersion=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release" | grep -o 'version*.*,' | cut -d '"' -f3)
     if [[ $(arch) == i386 ]]; then
-        downloadURL=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release" | grep -o "mac*.*.dmg" | cut -d '"' -f5)
+      downloadURL="https://download.jetbrains.com/product?code=PCP&latest&distribution=mac"
     elif [[ $(arch) == arm64 ]]; then
-        downloadURL=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release" | grep -o "macM1*.*.dmg" | cut -d '"' -f5)
+      downloadURL="https://download.jetbrains.com/product?code=PCP&latest&distribution=macM1"
     fi
-    appNewVersion=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release" | grep -o 'version*.*,' | cut -d '"' -f3)
     expectedTeamID="2ZEFAR8TH3"
     ;;
 jetbrainspycharmce|\


### PR DESCRIPTION
**PyCharm (Pro)**

- Added comment to distinguish between PyCharm and PyCharm CE (yeah, that one is quite confusing...)
- Changed `downloadURL`s to direct links for simplification. It does now use the same URL format as PyCharm CE does.
- Removed a doubled line of `appNewVersion`

**PyCharm CE**

- Added `downloadURL` for Apple Silicon
- Added `appNewVersion`