### PR TITLE
Updated 'webexteams' for Apple Silicon support

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -2582,9 +2582,13 @@ webexmeetings)
     ;;
 webexteams)
     # credit: Erik Stam (@erikstam)
-    name="Webex Teams"
+    name="Webex"
     type="dmg"
-    downloadURL="https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/WebexTeams.dmg"
+    if [[ $(arch) == arm64 ]]; then
+        downloadURL="https://binaries.webex.com/WebexDesktop-MACOS-Apple-Silicon-Gold/Webex.dmg"
+    elif [[ $(arch) == i386 ]]; then
+        downloadURL="https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/Webex.dmg"
+    fi
     expectedTeamID="DE8Y96K9QP"
     ;;
 whatsapp)


### PR DESCRIPTION
'Webex Teams' changed its application name to just 'Webex'.
Also there is an Apple Silicon version available now.
Should solve #156 