### PR TITLE
Fix to install googlejapaneseinput

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1468,6 +1468,7 @@ googlejapaneseinput)
     type="pkgInDmg"
     pkgName="GoogleJapaneseInput.pkg"
     downloadURL="https://dl.google.com/japanese-ime/latest/GoogleJapaneseInput.dmg"
+    blockingProcesses=( NONE )
     expectedTeamID="EQHXZ8M8AV"
     ;;
 gotomeeting)


### PR DESCRIPTION
Google Japanese Input app will be restarted by the launch daemon when the application is terminated.

The `checkBlockingProcesses` process kills the corresponding process and sleeps for a few seconds, so the behavior of the launch daemon causes an infinite loop.

Therefore, I thought it would be useful to avoid blockingProcesses as `NONE` for this application.